### PR TITLE
Paramiko AgentKeys aren't hashable

### DIFF
--- a/radssh/authmgr.py
+++ b/radssh/authmgr.py
@@ -299,7 +299,10 @@ class AuthManager(object):
                 else:
                     # Actual keys may not be loaded yet. Only loaded when actively used, so
                     # we don't prompt for passphrases unless we absolutely have to.
-                    if value not in self.deferred_keys:
+                    if type(value) is paramiko.AgentKey:
+                        key = value
+
+                    elif value not in self.deferred_keys:
                         # Not deferred - the value IS the key
                         key = value
                     elif not self.deferred_keys[value]:


### PR DESCRIPTION
If the key is received from an agent connection, they're an object that isn't hashable.

At this point it tries to see if value is in deferred_keys and raises a TypeError.

We can avoid this by just using the value as the key.