### PR TITLE
star_tty cpu spinning fix

### DIFF
--- a/radssh/core_plugins/star_tty.py
+++ b/radssh/core_plugins/star_tty.py
@@ -26,17 +26,18 @@ def posix_shell(chan, encoding='UTF-8'):
     partial_buf = b''
     try:
         while True:
-            r, w, e = select.select([chan, sys.stdin], [sys.stdout], [])
-            # Make sure we can read from socket and write to stdout...
-            if (chan in r) and (sys.stdout in w):
+            r, w, e = select.select([chan, sys.stdin], [], [])
+            if (chan in r):
                 try:
                     x = chan.recv(1024)
-                    if len(x) == 0:
-                        sys.stdout.write('\r\n*** EOF ***\r\n')
-                        break
-                    print((partial_buf + x).decode(encoding), end='')
-                    sys.stdout.flush()
-                    partial_buf = b''
+                    r1, w1, e1 = select.select([], [sys.stdout], [])
+                    if (sys.stdout in w1):
+                        if len(x) == 0:
+                            sys.stdout.write('\r\n*** EOF ***\r\n')
+                            break
+                        print((partial_buf + x).decode(encoding), end='')
+                        sys.stdout.flush()
+                        partial_buf = b''
                 except socket.timeout:
                     pass
                 except UnicodeError:


### PR DESCRIPTION
This change prevents select() from often returning immediately which caused this loop to spin quickly and eat 100% of a cpu core.  Code checks for ok to write only when its about to write.

@radssh please review/update.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexis.com>