### PR TITLE
adding additional installation steps

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,6 +16,12 @@ Installing from PyPI
 
 If you are installing to a virtual environment, be sure to activate the environment prior to running pip.
 
+Ubuntu needs some additional dependencies:
+``sudo apt-get install libssl-dev python-dev libffi-dev -y``
+
+CentOS requires additional depencies:
+``sudo yum install -y python-devel libffi-devel openssl-devel
+
 Run the command (with sudo, if needed): ``pip install radssh``
 
 This should download and install RadSSH from the internet, along with the dependency packages (as well as their own dependencies, etc.)


### PR DESCRIPTION
Adding additional debug installation steps for Centos and Ubuntu, this should help greatly as performing a normal pip install radssh ends with some very confusing errors. This should mitigate those.