### PR TITLE
Added shell alias fix

### DIFF
--- a/radssh/core_plugins/alias.py
+++ b/radssh/core_plugins/alias.py
@@ -49,13 +49,13 @@ def init(**kwargs):
     '''Use subprocess to get shell to source a likely alias defining file'''
     cmd = None
     if os.path.exists(os.path.expanduser('~/.bash_profile')):
-        cmd = ['bash', '-c',
+        cmd = ['bash', '-ic',
                'source ~/.bash_profile; alias| sed -e \'s/^alias //\'']
     elif os.path.exists(os.path.expanduser('~/.bashrc')):
-        cmd = ['bash', '-c',
+        cmd = ['bash', '-ic',
                'source ~/.bashrc; alias| sed -e \'s/^alias //\'']
     elif os.path.exists(os.path.expanduser('~/.profile')):
-        cmd = ['sh', '-c', 'source ~/.profile; alias']
+        cmd = ['sh', '-ic', '. ~/.profile; alias']
     if cmd:
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         p.wait()


### PR DESCRIPTION
Added -i to make shells interactive so that common .bashrc/.profile lines such as:
```
# If not running interactively, don't do anything
case $- in
    *i*) ;;
      *) return;;
esac
```
Do not cause early exit skipping alias lines later on in these files.

Also for bourne shell, 'source' cmd may not be found and the traditional '.' (dot) is used.

@radssh tested ok for me, please review.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>